### PR TITLE
Fix: Prevent API call hang and resolve async issues

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -94,7 +94,7 @@ async def generate_ppt(slide_request: SlideRequest):
         raise HTTPException(status_code=500, detail=f"Failed to generate prompt: {e}")
 
     try:
-        response = call_openai_with_retry(prompt)
+        response = await call_openai_with_retry(prompt)
         output_text = response.choices[0].message.content
         
         if output_text is None:


### PR DESCRIPTION
Refactored `openai_service.py` to use `AsyncOpenAI` and `asyncio` to provide robust timeout handling for OpenAI API calls. This prevents the application from hanging indefinitely if the OpenAI API is unresponsive.

- Changed `OpenAI` client to `AsyncOpenAI`.
- Made `call_openai_with_retry` an asynchronous function.
- Implemented `asyncio.wait_for` to enforce an overall timeout per API attempt.
- Replaced `time.sleep` with `await asyncio.sleep`.
- Added specific logging for `asyncio.TimeoutError`.

Modified `main.py` to correctly `await` the refactored `call_openai_with_retry` function, resolving an `AttributeError` that occurred after the initial async refactor.

The application now correctly handles API timeouts and errors, returning appropriate responses to the frontend instead of hanging. Testing confirmed that OpenAI rate limit/quota errors are now surfaced correctly.